### PR TITLE
Optimize encoding

### DIFF
--- a/modules/core/src/main/scala/mess/ast/MsgPack.scala
+++ b/modules/core/src/main/scala/mess/ast/MsgPack.scala
@@ -1,25 +1,74 @@
 package mess.ast
 
+import org.msgpack.core.MessagePacker
+
 import scala.collection.mutable
 
-sealed trait MsgPack
+sealed trait MsgPack {
+  def pack(acc: MessagePacker): Unit
+}
 object MsgPack {
-  final case object MEmpty                                          extends MsgPack
-  final case object MNil                                            extends MsgPack
-  final case class MBool(a: Boolean)                                extends MsgPack
-  final case class MString(a: String)                               extends MsgPack
-  final case class MByte(a: Byte)                                   extends MsgPack
-  final case class MExtension(typ: Byte, size: Int, a: Array[Byte]) extends MsgPack
-  final case class MShort(a: Short)                                 extends MsgPack
-  final case class MInt(a: Int)                                     extends MsgPack
-  final case class MLong(a: Long)                                   extends MsgPack
-  final case class MBigInt(a: BigInt)                               extends MsgPack
-  final case class MDouble(a: Double)                               extends MsgPack
-  final case class MFloat(a: Float)                                 extends MsgPack
-  final case class MArray(a: Vector[MsgPack])                       extends MsgPack
+  final case object MEmpty extends MsgPack {
+    def pack(acc: MessagePacker): Unit = ()
+  }
+  final case object MNil extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packNil()
+  }
+  final case class MBool(a: Boolean) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packBoolean(a)
+  }
+  final case class MString(a: String) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packString(a)
+  }
+  final case class MByte(a: Byte) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packByte(a)
+  }
+  final case class MShort(a: Short) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packShort(a)
+  }
+  final case class MInt(a: Int) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packInt(a)
+  }
+  final case class MLong(a: Long) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packLong(a)
+  }
+  final case class MBigInt(a: BigInt) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packBigInteger(a.bigInteger)
+  }
+  final case class MDouble(a: Double) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packDouble(a)
+  }
+  final case class MFloat(a: Float) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = acc.packFloat(a)
+  }
+  final case class MArray(a: Vector[MsgPack]) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = {
+      acc.packArrayHeader(a.size)
+      val it = a.iterator
+      while (it.hasNext) {
+        it.next.pack(acc)
+      }
+    }
+  }
   final case class MMap(a: mutable.LinkedHashMap[MsgPack, MsgPack]) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = {
+      acc.packMapHeader(a.size)
+      val it = a.iterator
+      while (it.hasNext) {
+        val (k, v) = it.next
+        k.pack(acc)
+        v.pack(acc)
+      }
+    }
+
     def add(k: MsgPack, v: MsgPack): MsgPack = {
       this.copy(a += k -> v)
+    }
+  }
+  final case class MExtension(typ: Byte, size: Int, a: Array[Byte]) extends MsgPack {
+    def pack(acc: MessagePacker): Unit = {
+      acc.packExtensionTypeHeader(typ, size)
+      acc.writePayload(a)
     }
   }
 }

--- a/modules/core/src/main/scala/mess/codec/Codec.scala
+++ b/modules/core/src/main/scala/mess/codec/Codec.scala
@@ -66,30 +66,5 @@ object Codec {
       }
   }
 
-  def serialize(m: MsgPack, acc: MessagePacker): Unit = m match {
-    case MsgPack.MEmpty     => ()
-    case MsgPack.MNil       => acc.packNil()
-    case MsgPack.MBool(a)   => acc.packBoolean(a)
-    case MsgPack.MByte(a)   => acc.packByte(a)
-    case MsgPack.MShort(a)  => acc.packShort(a)
-    case MsgPack.MInt(a)    => acc.packInt(a)
-    case MsgPack.MLong(a)   => acc.packLong(a)
-    case MsgPack.MBigInt(a) => acc.packBigInteger(a.bigInteger)
-    case MsgPack.MFloat(a)  => acc.packFloat(a)
-    case MsgPack.MDouble(a) => acc.packDouble(a)
-    case MsgPack.MString(a) => acc.packString(a)
-    case MsgPack.MExtension(t, s, a) =>
-      acc.packExtensionTypeHeader(t, s)
-      acc.writePayload(a)
-    case MsgPack.MArray(a) =>
-      acc.packArrayHeader(a.size)
-      a.foreach(serialize(_, acc))
-    case MsgPack.MMap(a) =>
-      acc.packMapHeader(a.size)
-      a.iterator.foreach {
-        case (k, v) =>
-          serialize(k, acc)
-          serialize(v, acc)
-      }
-  }
+  def serialize(m: MsgPack, acc: MessagePacker): Unit = m.pack(acc)
 }


### PR DESCRIPTION
**before**

```
[info] Benchmark                Mode  Cnt         Score        Error  Units
[info] PackBench.encodeLong10  thrpt   20    587087.901 ±   6823.606  ops/s
[info] PackBench.encodeLong30  thrpt   20    173658.439 ±   4693.170  ops/s
[info] PackBench.encodeLong60  thrpt   20     84979.790 ±    647.158  ops/s
[info] PackBench.encodeStr16   thrpt   20      1890.081 ±     23.378  ops/s
[info] PackBench.encodeStr32   thrpt   20       212.593 ±      4.016  ops/s
[info] PackBench.encodeUInt32  thrpt   20  16181031.943 ± 187892.007  ops/s
[info] PackBench.encodeUInt64  thrpt   20  15177198.338 ± 270294.091  ops/s
```


**after**

```
[info] Benchmark                Mode  Cnt         Score        Error  Units
[info] PackBench.encodeLong10  thrpt   20    663953.840 ±  26295.855  ops/s
[info] PackBench.encodeLong30  thrpt   20    197258.633 ±  12261.447  ops/s
[info] PackBench.encodeLong60  thrpt   20     98553.763 ±   2076.013  ops/s
[info] PackBench.encodeStr16   thrpt   20      1860.762 ±     32.553  ops/s
[info] PackBench.encodeStr32   thrpt   20       212.802 ±      4.494  ops/s
[info] PackBench.encodeUInt32  thrpt   20  17539041.255 ± 348184.506  ops/s
[info] PackBench.encodeUInt64  thrpt   20  17680763.769 ± 123762.091  ops/s
```
