### PR TITLE
Improve immutability of the MMap

### DIFF
--- a/modules/core/src/main/scala/mess/Encoder.scala
+++ b/modules/core/src/main/scala/mess/Encoder.scala
@@ -28,55 +28,55 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
   }
 
   implicit final val encodeBoolean: Encoder[Boolean] = new Encoder[Boolean] {
-    def apply(a: Boolean): MsgPack = MsgPack.mBool(a)
+    def apply(a: Boolean): MsgPack = MsgPack.fromBoolean(a)
   }
 
-  implicit final val encodeBytes: Encoder[Array[Byte]] = Encoder.instance[Array[Byte]](MsgPack.mBin)
+  implicit final val encodeBytes: Encoder[Array[Byte]] = Encoder.instance[Array[Byte]](MsgPack.fromBytes)
 
   implicit final val encodeByte: Encoder[Byte] = new Encoder[Byte] {
-    def apply(a: Byte): MsgPack = MsgPack.mByte(a)
+    def apply(a: Byte): MsgPack = MsgPack.fromByte(a)
   }
 
   implicit final val encodeShort: Encoder[Short] = new Encoder[Short] {
-    def apply(a: Short): MsgPack = MsgPack.mShort(a)
+    def apply(a: Short): MsgPack = MsgPack.fromShort(a)
   }
 
   implicit final val encodeInt: Encoder[Int] = new Encoder[Int] {
-    def apply(a: Int): MsgPack = MsgPack.mInt(a)
+    def apply(a: Int): MsgPack = MsgPack.fromInt(a)
   }
 
   implicit final val encodeLong: Encoder[Long] = new Encoder[Long] {
-    def apply(a: Long): MsgPack = MsgPack.mLong(a)
+    def apply(a: Long): MsgPack = MsgPack.fromLong(a)
   }
 
   implicit final val encodeBigInt: Encoder[BigInt] = new Encoder[BigInt] {
-    def apply(a: BigInt): MsgPack = MsgPack.mBigInt(a)
+    def apply(a: BigInt): MsgPack = MsgPack.fromBigInt(a)
   }
 
   implicit final val encodeDouble: Encoder[Double] = new Encoder[Double] {
-    def apply(a: Double): MsgPack = MsgPack.mDouble(a)
+    def apply(a: Double): MsgPack = MsgPack.fromDouble(a)
   }
 
   implicit final val encodeFloat: Encoder[Float] = new Encoder[Float] {
-    def apply(a: Float): MsgPack = MsgPack.mFloat(a)
+    def apply(a: Float): MsgPack = MsgPack.fromFloat(a)
   }
 
   implicit final val encodeChar: Encoder[Char] = new Encoder[Char] {
-    def apply(a: Char): MsgPack = MsgPack.mStr(a.toString)
+    def apply(a: Char): MsgPack = MsgPack.fromString(a.toString)
   }
 
   implicit final val encodeString: Encoder[String] = new Encoder[String] {
-    def apply(a: String): MsgPack = MsgPack.mStr(a)
+    def apply(a: String): MsgPack = MsgPack.fromString(a)
   }
 
   implicit final def encodeSymbol[K <: Symbol]: Encoder[K] = new Encoder[K] {
-    def apply(a: K): MsgPack = MsgPack.mStr(a.name)
+    def apply(a: K): MsgPack = MsgPack.fromString(a.name)
   }
 
   implicit final def encodeOption[A](implicit A: Encoder[A]): Encoder[Option[A]] = new Encoder[Option[A]] {
     def apply(a: Option[A]): MsgPack = a match {
       case Some(v) => A(v)
-      case None    => MsgPack.mNil
+      case None    => MsgPack.nil
     }
   }
 
@@ -84,7 +84,7 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
     A.contramap[Some[A]](_.get)
 
   implicit final val encodeNone: Encoder[None.type] = new Encoder[None.type] {
-    def apply(a: None.type): MsgPack = MsgPack.mNil
+    def apply(a: None.type): MsgPack = MsgPack.nil
   }
 
   @tailrec private[this] def iterLoop[A](rem: Iterator[A], acc: mutable.Builder[MsgPack, Vector[MsgPack]])(
@@ -94,25 +94,25 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
 
   implicit final def encodeSeq[A: Encoder]: Encoder[Seq[A]] = new Encoder[Seq[A]] {
     def apply(a: Seq[A]): MsgPack = {
-      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
   implicit final def encodeSet[A: Encoder]: Encoder[Set[A]] = new Encoder[Set[A]] {
     def apply(a: Set[A]): MsgPack = {
-      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
   implicit final def encodeList[A: Encoder]: Encoder[List[A]] = new Encoder[List[A]] {
     def apply(a: List[A]): MsgPack = {
-      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
   implicit final def encodeVector[A: Encoder]: Encoder[Vector[A]] = new Encoder[Vector[A]] {
     def apply(a: Vector[A]): MsgPack = {
-      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
@@ -133,7 +133,7 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
                                      V: Encoder[V]): Encoder[Map[K, V]] =
     new Encoder[Map[K, V]] {
       def apply(a: Map[K, V]): MsgPack =
-        MsgPack.mMapFromSeq(mapLoop(a.iterator, Seq.newBuilder))
+        MsgPack.fromPairSeq(mapLoop(a.iterator, Seq.newBuilder))
     }
 }
 

--- a/modules/core/src/main/scala/mess/Encoder.scala
+++ b/modules/core/src/main/scala/mess/Encoder.scala
@@ -94,33 +94,34 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
 
   implicit final def encodeSeq[A: Encoder]: Encoder[Seq[A]] = new Encoder[Seq[A]] {
     def apply(a: Seq[A]): MsgPack = {
-      MsgPack.mArr(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
   implicit final def encodeSet[A: Encoder]: Encoder[Set[A]] = new Encoder[Set[A]] {
     def apply(a: Set[A]): MsgPack = {
-      MsgPack.mArr(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
   implicit final def encodeList[A: Encoder]: Encoder[List[A]] = new Encoder[List[A]] {
     def apply(a: List[A]): MsgPack = {
-      MsgPack.mArr(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
   implicit final def encodeVector[A: Encoder]: Encoder[Vector[A]] = new Encoder[Vector[A]] {
     def apply(a: Vector[A]): MsgPack = {
-      MsgPack.mArr(iterLoop(a.iterator, Vector.newBuilder))
+      MsgPack.mArrFromVector(iterLoop(a.iterator, Vector.newBuilder))
     }
   }
 
-  @tailrec private[this] def mapLoop[K, V](it: Iterator[(K, V)], acc: mutable.HashMap[MsgPack, MsgPack])(
+  @tailrec private[this] def mapLoop[K, V](it: Iterator[(K, V)],
+                                           acc: mutable.Builder[(MsgPack, MsgPack), Seq[(MsgPack, MsgPack)]])(
       implicit
       K: Encoder[K],
-      V: Encoder[V]): mutable.HashMap[MsgPack, MsgPack] = {
-    if (!it.hasNext) acc
+      V: Encoder[V]): Seq[(MsgPack, MsgPack)] = {
+    if (!it.hasNext) acc.result()
     else {
       val (k, v) = it.next()
       mapLoop(it, acc += K(k) -> V(v))
@@ -132,7 +133,7 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
                                      V: Encoder[V]): Encoder[Map[K, V]] =
     new Encoder[Map[K, V]] {
       def apply(a: Map[K, V]): MsgPack =
-        MsgPack.mMap(mapLoop(a.iterator, mutable.HashMap.empty))
+        MsgPack.mMapFromSeq(mapLoop(a.iterator, Seq.newBuilder))
     }
 }
 

--- a/modules/core/src/main/scala/mess/ast/MsgPack.scala
+++ b/modules/core/src/main/scala/mess/ast/MsgPack.scala
@@ -376,20 +376,20 @@ object MsgPack {
   final val True  = MBool(true)
   final val False = MBool(false)
 
-  def mNil: MsgPack                                        = MNil
-  def mEmpty: MsgPack                                      = MEmpty
-  def mMap(xs: (MsgPack, MsgPack)*): MsgPack               = MMap(mutable.HashMap(xs: _*))
-  def mMap(xs: mutable.HashMap[MsgPack, MsgPack]): MsgPack = MMap(xs)
-  def mArr(xs: MsgPack*): MsgPack                          = MArray(Vector(xs: _*))
-  def mArr(xs: Vector[MsgPack]): MsgPack                   = MArray(xs)
-  def mBool(x: Boolean): MsgPack                           = if (x) True else False
-  def mStr(x: String): MsgPack                             = MString(x)
-  def mBigInt(x: BigInt): MsgPack                          = MBigInt(x)
-  def mByte(x: Byte): MsgPack                              = MByte(x)
-  def mShort(x: Short): MsgPack                            = MShort(x)
-  def mInt(x: Int): MsgPack                                = MInt(x)
-  def mLong(x: Long): MsgPack                              = MLong(x)
-  def mFloat(x: Float): MsgPack                            = MFloat(x)
-  def mDouble(x: Double): MsgPack                          = MDouble(x)
-  def mBin(x: Array[Byte]): MsgPack                        = MBin(x)
+  def mNil: MsgPack                                     = MNil
+  def mEmpty: MsgPack                                   = MEmpty
+  def mMap(xs: (MsgPack, MsgPack)*): MsgPack            = MMap(mutable.HashMap(xs: _*))
+  def mMapFromSeq(xs: Seq[(MsgPack, MsgPack)]): MsgPack = MMap(mutable.HashMap(xs: _*))
+  def mArr(xs: MsgPack*): MsgPack                       = MArray(Vector(xs: _*))
+  def mArrFromVector(xs: Vector[MsgPack]): MsgPack      = MArray(xs)
+  def mBool(x: Boolean): MsgPack                        = if (x) True else False
+  def mStr(x: String): MsgPack                          = MString(x)
+  def mBigInt(x: BigInt): MsgPack                       = MBigInt(x)
+  def mByte(x: Byte): MsgPack                           = MByte(x)
+  def mShort(x: Short): MsgPack                         = MShort(x)
+  def mInt(x: Int): MsgPack                             = MInt(x)
+  def mLong(x: Long): MsgPack                           = MLong(x)
+  def mFloat(x: Float): MsgPack                         = MFloat(x)
+  def mDouble(x: Double): MsgPack                       = MDouble(x)
+  def mBin(x: Array[Byte]): MsgPack                     = MBin(x)
 }

--- a/modules/core/src/main/scala/mess/ast/MsgPack.scala
+++ b/modules/core/src/main/scala/mess/ast/MsgPack.scala
@@ -373,23 +373,23 @@ object MsgPack {
       }
   }
 
-  final val True  = MBool(true)
-  final val False = MBool(false)
+  private[this] final val True  = MBool(true)
+  private[this] final val False = MBool(false)
 
-  def mNil: MsgPack                                     = MNil
-  def mEmpty: MsgPack                                   = MEmpty
-  def mMap(xs: (MsgPack, MsgPack)*): MsgPack            = MMap(mutable.HashMap(xs: _*))
-  def mMapFromSeq(xs: Seq[(MsgPack, MsgPack)]): MsgPack = MMap(mutable.HashMap(xs: _*))
-  def mArr(xs: MsgPack*): MsgPack                       = MArray(Vector(xs: _*))
-  def mArrFromVector(xs: Vector[MsgPack]): MsgPack      = MArray(xs)
-  def mBool(x: Boolean): MsgPack                        = if (x) True else False
-  def mStr(x: String): MsgPack                          = MString(x)
-  def mBigInt(x: BigInt): MsgPack                       = MBigInt(x)
-  def mByte(x: Byte): MsgPack                           = MByte(x)
-  def mShort(x: Short): MsgPack                         = MShort(x)
-  def mInt(x: Int): MsgPack                             = MInt(x)
-  def mLong(x: Long): MsgPack                           = MLong(x)
-  def mFloat(x: Float): MsgPack                         = MFloat(x)
-  def mDouble(x: Double): MsgPack                       = MDouble(x)
-  def mBin(x: Array[Byte]): MsgPack                     = MBin(x)
+  def nil: MsgPack                                      = MNil
+  def empty: MsgPack                                    = MEmpty
+  def fromPairs(xs: (MsgPack, MsgPack)*): MsgPack       = MMap(mutable.HashMap(xs: _*))
+  def fromPairSeq(xs: Seq[(MsgPack, MsgPack)]): MsgPack = MMap(mutable.HashMap(xs: _*))
+  def fromValues(xs: MsgPack*): MsgPack                 = MArray(Vector(xs: _*))
+  def fromVector(xs: Vector[MsgPack]): MsgPack          = MArray(xs)
+  def fromBoolean(x: Boolean): MsgPack                  = if (x) True else False
+  def fromString(x: String): MsgPack                    = MString(x)
+  def fromBigInt(x: BigInt): MsgPack                    = MBigInt(x)
+  def fromByte(x: Byte): MsgPack                        = MByte(x)
+  def fromShort(x: Short): MsgPack                      = MShort(x)
+  def fromInt(x: Int): MsgPack                          = MInt(x)
+  def fromLong(x: Long): MsgPack                        = MLong(x)
+  def fromFloat(x: Float): MsgPack                      = MFloat(x)
+  def fromDouble(x: Double): MsgPack                    = MDouble(x)
+  def fromBytes(x: Array[Byte]): MsgPack                = MBin(x)
 }

--- a/modules/core/src/test/scala/mess/DecoderSpec.scala
+++ b/modules/core/src/test/scala/mess/DecoderSpec.scala
@@ -30,7 +30,7 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Some[A]]") {
     check {
       Seq(
-        (Some(1), MsgPack.mInt(1))
+        (Some(1), MsgPack.fromInt(1))
       )
     }
   }
@@ -38,7 +38,7 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Char]") {
     check {
       Seq(
-        ('a', MsgPack.mStr("a"))
+        ('a', MsgPack.fromString("a"))
       )
     }
   }
@@ -46,20 +46,20 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Array[Byte]]") {
     check {
       Seq(
-        (Array(0x11, 0x1a).map(_.toByte), MsgPack.mBin(Array(0x11, 0x1a).map(_.toByte)))
+        (Array(0x11, 0x1a).map(_.toByte), MsgPack.fromBytes(Array(0x11, 0x1a).map(_.toByte)))
       )
     }
   }
 
   test("Decoder[Char] failure") {
-    val msg = MsgPack.mStr("ab")
+    val msg = MsgPack.fromString("ab")
     assert(decode[Char](msg) === Left(TypeMismatchError("Char", msg)))
   }
 
   test("Decoder[None.type]") {
     check {
       Seq(
-        (None, MsgPack.mNil)
+        (None, MsgPack.nil)
       )
     }
   }
@@ -67,8 +67,8 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Option[A]]") {
     check {
       Seq(
-        (Option(1), MsgPack.mInt(1)),
-        (Option.empty[Int], MsgPack.mNil)
+        (Option(1), MsgPack.fromInt(1)),
+        (Option.empty[Int], MsgPack.nil)
       )
     }
   }
@@ -76,174 +76,174 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Boolean]") {
     check {
       Seq(
-        (true, MsgPack.True),
-        (false, MsgPack.False)
+        (true, MsgPack.fromBoolean(true)),
+        (false, MsgPack.fromBoolean(false))
       )
     }
   }
 
   test("Decoder[Boolean] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Boolean](msg) === Left(TypeMismatchError("Boolean", msg)))
   }
 
   test("Decoder[Byte]") {
     check {
       Seq(
-        (0.toByte, MsgPack.mByte(0.toByte)),
-        (1.toByte, MsgPack.mInt(1)),
-        (2.toByte, MsgPack.mShort(2.toShort)),
-        (3.toByte, MsgPack.mLong(3L)),
-        (4.toByte, MsgPack.mBigInt(BigInt(4)))
+        (0.toByte, MsgPack.fromByte(0.toByte)),
+        (1.toByte, MsgPack.fromInt(1)),
+        (2.toByte, MsgPack.fromShort(2.toShort)),
+        (3.toByte, MsgPack.fromLong(3L)),
+        (4.toByte, MsgPack.fromBigInt(BigInt(4)))
       )
     }
   }
 
   test("Decoder[Byte] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Byte](msg) === Left(TypeMismatchError("Byte", msg)))
   }
 
   test("Decoder[Short]") {
     check {
       Seq(
-        (0.toShort, MsgPack.mByte(0.toByte)),
-        (1.toShort, MsgPack.mInt(1)),
-        (2.toShort, MsgPack.mShort(2.toShort)),
-        (3.toShort, MsgPack.mLong(3L)),
-        (4.toShort, MsgPack.mBigInt(BigInt(4)))
+        (0.toShort, MsgPack.fromByte(0.toByte)),
+        (1.toShort, MsgPack.fromInt(1)),
+        (2.toShort, MsgPack.fromShort(2.toShort)),
+        (3.toShort, MsgPack.fromLong(3L)),
+        (4.toShort, MsgPack.fromBigInt(BigInt(4)))
       )
     }
   }
 
   test("Decoder[Short] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Short](msg) === Left(TypeMismatchError("Short", msg)))
   }
 
   test("Decoder[Int]") {
     check {
       Seq(
-        (0, MsgPack.mByte(0.toByte)),
-        (1, MsgPack.mInt(1)),
-        (2, MsgPack.mShort(2.toShort)),
-        (3, MsgPack.mLong(3L)),
-        (4, MsgPack.mBigInt(BigInt(4)))
+        (0, MsgPack.fromByte(0.toByte)),
+        (1, MsgPack.fromInt(1)),
+        (2, MsgPack.fromShort(2.toShort)),
+        (3, MsgPack.fromLong(3L)),
+        (4, MsgPack.fromBigInt(BigInt(4)))
       )
     }
   }
 
   test("Decoder[Int] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Int](msg) === Left(TypeMismatchError("Int", msg)))
   }
 
   test("Decoder[Long]") {
     check {
       Seq(
-        (0L, MsgPack.mByte(0.toByte)),
-        (1L, MsgPack.mInt(1)),
-        (2L, MsgPack.mShort(2.toShort)),
-        (3L, MsgPack.mLong(3L)),
-        (4L, MsgPack.mBigInt(BigInt(4)))
+        (0L, MsgPack.fromByte(0.toByte)),
+        (1L, MsgPack.fromInt(1)),
+        (2L, MsgPack.fromShort(2.toShort)),
+        (3L, MsgPack.fromLong(3L)),
+        (4L, MsgPack.fromBigInt(BigInt(4)))
       )
     }
   }
 
   test("Decoder[Long] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Long](msg) === Left(TypeMismatchError("Long", msg)))
   }
 
   test("Decoder[BigInt]") {
     check {
       Seq(
-        (BigInt(0), MsgPack.mByte(0.toByte)),
-        (BigInt(1), MsgPack.mInt(1)),
-        (BigInt(2), MsgPack.mShort(2.toShort)),
-        (BigInt(3), MsgPack.mLong(3L)),
-        (BigInt(4), MsgPack.mBigInt(BigInt(4)))
+        (BigInt(0), MsgPack.fromByte(0.toByte)),
+        (BigInt(1), MsgPack.fromInt(1)),
+        (BigInt(2), MsgPack.fromShort(2.toShort)),
+        (BigInt(3), MsgPack.fromLong(3L)),
+        (BigInt(4), MsgPack.fromBigInt(BigInt(4)))
       )
     }
   }
 
   test("Decoder[BigInt] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[BigInt](msg) === Left(TypeMismatchError("BigInt", msg)))
   }
 
   test("Decoder[Double]") {
     check {
       Seq(
-        (0.0, MsgPack.mFloat(0.0f)),
-        (0.1, MsgPack.mDouble(0.1))
+        (0.0, MsgPack.fromFloat(0.0f)),
+        (0.1, MsgPack.fromDouble(0.1))
       )
     }
   }
 
   test("Decoder[Double] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Double](msg) === Left(TypeMismatchError("Double", msg)))
   }
 
   test("Decoder[Float]") {
     check {
       Seq(
-        (0.0f, MsgPack.mFloat(0.0f)),
-        (0.1f, MsgPack.mDouble(0.1))
+        (0.0f, MsgPack.fromFloat(0.0f)),
+        (0.1f, MsgPack.fromDouble(0.1))
       )
     }
   }
 
   test("Decoder[Float] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[Float](msg) === Left(TypeMismatchError("Float", msg)))
   }
 
   test("Decoder[String]") {
     check {
       Seq(
-        ("abjioeweuo", MsgPack.mStr("abjioeweuo"))
+        ("abjioeweuo", MsgPack.fromString("abjioeweuo"))
       )
     }
   }
 
   test("Decoder[String] failure") {
-    val msg = MsgPack.mEmpty
+    val msg = MsgPack.empty
     assert(decode[String](msg) === Left(TypeMismatchError("String", msg)))
   }
 
   test("Decoder[Seq[A]]") {
     check {
       Seq(
-        (Seq(0 to 14: _*), MsgPack.mArr((0 to 14).map(MsgPack.mInt): _*)),
-        (Seq.empty[Int], MsgPack.mEmpty)
+        (Seq(0 to 14: _*), MsgPack.fromValues((0 to 14).map(MsgPack.fromInt): _*)),
+        (Seq.empty[Int], MsgPack.empty)
       )
     }
   }
 
   test("Decoder[Seq[A]] failure") {
-    val msg = MsgPack.mStr("")
+    val msg = MsgPack.fromString("")
     assert(decode[Seq[Int]](msg) === Left(TypeMismatchError("C[A]", msg)))
   }
 
   test("Decoder[Tuple2[A]]") {
     check {
       Seq(
-        ((1, 2), MsgPack.mArr(MsgPack.mByte(1.toByte), MsgPack.mByte(2.toByte)))
+        ((1, 2), MsgPack.fromValues(MsgPack.fromByte(1.toByte), MsgPack.fromByte(2.toByte)))
       )
     }
   }
 
   test("Decoder[Tuple2[A]] failure") {
-    val msg = MsgPack.mArr(MsgPack.mInt(1), MsgPack.mInt(2), MsgPack.mInt(3))
+    val msg = MsgPack.fromValues(MsgPack.fromInt(1), MsgPack.fromInt(2), MsgPack.fromInt(3))
     assert(decode[(Int, Int)](msg) === Left(TypeMismatchError("(A, B)", msg)))
   }
 
   test("Decoder[List[A]]") {
     check {
       Seq(
-        (List(0 to 14: _*), MsgPack.mArr((0 to 14).map(MsgPack.mInt): _*))
+        (List(0 to 14: _*), MsgPack.fromValues((0 to 14).map(MsgPack.fromInt): _*))
       )
     }
   }
@@ -251,7 +251,7 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Vector[A]]") {
     check {
       Seq(
-        (Vector(0 to 14: _*), MsgPack.mArr((0 to 14).map(MsgPack.mInt): _*))
+        (Vector(0 to 14: _*), MsgPack.fromValues((0 to 14).map(MsgPack.fromInt): _*))
       )
     }
   }
@@ -259,16 +259,16 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Map[A, B]]") {
     check {
       Seq(
-        (('a' to 'z').zip(0 to 14).toMap, MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
-          case (k, v) => MsgPack.mStr(k.toString) -> MsgPack.mByte(v.toByte)
+        (('a' to 'z').zip(0 to 14).toMap, MsgPack.fromPairSeq(('a' to 'z').zip(0 to 14).map {
+          case (k, v) => MsgPack.fromString(k.toString) -> MsgPack.fromByte(v.toByte)
         })),
-        (Map.empty[Char, Int], MsgPack.mEmpty)
+        (Map.empty[Char, Int], MsgPack.empty)
       )
     }
   }
 
   test("Decoder[Map[A, B]] failure") {
-    val msg = MsgPack.mStr("")
+    val msg = MsgPack.fromString("")
     assert(decode[Map[Int, Int]](msg) === Left(TypeMismatchError("M[K, V]", msg)))
   }
 
@@ -276,9 +276,10 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
     check {
       Seq(
         (('a' to 'z').zip((0 to 14).map(a => Bar(a.toDouble))).toMap,
-         MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
+         MsgPack.fromPairSeq(('a' to 'z').zip(0 to 14).map {
            case (k, v) =>
-             MsgPack.mStr(k.toString) -> MsgPack.mMap(MsgPack.mStr("double") -> MsgPack.mDouble(v.toDouble))
+             MsgPack.fromString(k.toString) -> MsgPack.fromPairs(
+               MsgPack.fromString("double") -> MsgPack.fromDouble(v.toDouble))
          }))
       )
     }
@@ -287,32 +288,37 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Qux]") {
     check {
       Seq(
-        (Qux(None), MsgPack.mMap(MsgPack.mStr("byte")    -> MsgPack.mNil)),
-        (Qux(Some(1)), MsgPack.mMap(MsgPack.mStr("byte") -> MsgPack.mByte(1.toByte)))
+        (Qux(None), MsgPack.fromPairs(MsgPack.fromString("byte")    -> MsgPack.nil)),
+        (Qux(Some(1)), MsgPack.fromPairs(MsgPack.fromString("byte") -> MsgPack.fromByte(1.toByte)))
       )
     }
   }
 
   test("Decoder[Qux] failure") {
-    assert(decode[Qux](MsgPack.mStr(" ")) === Left(TypeMismatchError("FieldType[K, H] :: T", MsgPack.mStr(" "))))
-    val a = decode[Qux](MsgPack.mMap(MsgPack.mStr("byte") -> MsgPack.mStr(" ")))
-    assert(a === Left(TypeMismatchError("Int", MsgPack.mStr(" "))))
+    assert(
+      decode[Qux](MsgPack.fromString(" ")) === Left(TypeMismatchError("FieldType[K, H] :: T", MsgPack.fromString(" "))))
+    val a = decode[Qux](MsgPack.fromPairs(MsgPack.fromString("byte") -> MsgPack.fromString(" ")))
+    assert(a === Left(TypeMismatchError("Int", MsgPack.fromString(" "))))
   }
 
   test("Decoder[Z]") {
     check {
       Seq[(Z, MsgPack)](
-        (Z0(1), MsgPack.mMap(MsgPack.mStr("Z0") -> MsgPack.mMap(MsgPack.mStr("a") -> MsgPack.mByte(1.toByte)))),
-        (Z1(2), MsgPack.mMap(MsgPack.mStr("Z1") -> MsgPack.mMap(MsgPack.mStr("b") -> MsgPack.mByte(2.toByte))))
+        (Z0(1),
+         MsgPack.fromPairs(
+           MsgPack.fromString("Z0") -> MsgPack.fromPairs(MsgPack.fromString("a") -> MsgPack.fromByte(1.toByte)))),
+        (Z1(2),
+         MsgPack.fromPairs(
+           MsgPack.fromString("Z1") -> MsgPack.fromPairs(MsgPack.fromString("b") -> MsgPack.fromByte(2.toByte))))
       )
     }
   }
 
   test("Decoder[Z] failure") {
-    val a = decode[Z](MsgPack.mStr(" "))
-    assert(a === Left(TypeMismatchError("FieldType[K, L] :+: R", MsgPack.mStr(" "))))
-    val b = decode[Z](MsgPack.mMap(MsgPack.mStr("Z2") -> MsgPack.mInt(1)))
-    assert(b === Left(TypeMismatchError("CNil", MsgPack.mMap(MsgPack.mStr("Z2") -> MsgPack.mInt(1)))))
+    val a = decode[Z](MsgPack.fromString(" "))
+    assert(a === Left(TypeMismatchError("FieldType[K, L] :+: R", MsgPack.fromString(" "))))
+    val b = decode[Z](MsgPack.fromPairs(MsgPack.fromString("Z2") -> MsgPack.fromInt(1)))
+    assert(b === Left(TypeMismatchError("CNil", MsgPack.fromPairs(MsgPack.fromString("Z2") -> MsgPack.fromInt(1)))))
   }
 
   test("map") {

--- a/modules/core/src/test/scala/mess/DecoderSpec.scala
+++ b/modules/core/src/test/scala/mess/DecoderSpec.scala
@@ -259,9 +259,9 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Map[A, B]]") {
     check {
       Seq(
-        (('a' to 'z').zip(0 to 14).toMap, MsgPack.mMap(('a' to 'z').zip(0 to 14).map {
+        (('a' to 'z').zip(0 to 14).toMap, MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
           case (k, v) => MsgPack.mStr(k.toString) -> MsgPack.mByte(v.toByte)
-        }: _*)),
+        })),
         (Map.empty[Char, Int], MsgPack.mEmpty)
       )
     }
@@ -275,9 +275,11 @@ class DecoderSpec extends FunSuite with MsgpackHelper {
   test("Decoder[Map[A, Bar]]") {
     check {
       Seq(
-        (('a' to 'z').zip((0 to 14).map(a => Bar(a.toDouble))).toMap, MsgPack.mMap(('a' to 'z').zip(0 to 14).map {
-          case (k, v) => MsgPack.mStr(k.toString) -> MsgPack.mMap(MsgPack.mStr("double") -> MsgPack.mDouble(v.toDouble))
-        }: _*))
+        (('a' to 'z').zip((0 to 14).map(a => Bar(a.toDouble))).toMap,
+         MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
+           case (k, v) =>
+             MsgPack.mStr(k.toString) -> MsgPack.mMap(MsgPack.mStr("double") -> MsgPack.mDouble(v.toDouble))
+         }))
       )
     }
   }

--- a/modules/core/src/test/scala/mess/EncoderSpec.scala
+++ b/modules/core/src/test/scala/mess/EncoderSpec.scala
@@ -170,9 +170,9 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Map[A, B]]") {
     check {
       Seq(
-        (('a' to 'z').zip(0 to 14).toMap, MsgPack.mMap(('a' to 'z').zip(0 to 14).map {
+        (('a' to 'z').zip(0 to 14).toMap, MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
           case (k, v) => MsgPack.mStr(k.toString) -> MsgPack.mByte(v.toByte)
-        }: _*)),
+        })),
         (Map.empty[Char, Int], MsgPack.mMap())
       )
     }
@@ -182,9 +182,11 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
     import mess.codec.generic.derived._
     check {
       Seq(
-        (('a' to 'z').zip((0 to 14).map(a => Bar(a.toDouble))).toMap, MsgPack.mMap(('a' to 'z').zip(0 to 14).map {
-          case (k, v) => MsgPack.mStr(k.toString) -> MsgPack.mMap(MsgPack.mStr("double") -> MsgPack.mDouble(v.toDouble))
-        }: _*))
+        (('a' to 'z').zip((0 to 14).map(a => Bar(a.toDouble))).toMap,
+         MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
+           case (k, v) =>
+             MsgPack.mStr(k.toString) -> MsgPack.mMap(MsgPack.mStr("double") -> MsgPack.mDouble(v.toDouble))
+         }))
       )
     }
   }

--- a/modules/core/src/test/scala/mess/EncoderSpec.scala
+++ b/modules/core/src/test/scala/mess/EncoderSpec.scala
@@ -23,27 +23,27 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
 
   test("Encoder[Some[A]]") {
     check {
-      Seq((Some(1), MsgPack.mByte(1.toByte)))
+      Seq((Some(1), MsgPack.fromByte(1.toByte)))
     }
   }
 
   test("Encoder[Char]") {
     check {
-      Seq(('a', MsgPack.mStr("a")))
+      Seq(('a', MsgPack.fromString("a")))
     }
   }
 
   test("Encoder[None.type]") {
     check {
-      Seq((None, MsgPack.mNil))
+      Seq((None, MsgPack.nil))
     }
   }
 
   test("Encoder[Option[A]]") {
     check {
       Seq(
-        (Option(Int.MaxValue), MsgPack.mInt(Int.MaxValue)),
-        (Option.empty[Int], MsgPack.mNil)
+        (Option(Int.MaxValue), MsgPack.fromInt(Int.MaxValue)),
+        (Option.empty[Int], MsgPack.nil)
       )
     }
   }
@@ -51,8 +51,8 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Boolean]") {
     check {
       Seq(
-        (true, MsgPack.True),
-        (false, MsgPack.False)
+        (true, MsgPack.fromBoolean(true)),
+        (false, MsgPack.fromBoolean(false))
       )
     }
   }
@@ -60,11 +60,11 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Byte]") {
     check {
       Seq(
-        (0.toByte, MsgPack.mByte(0.toByte)),
-        ((-32).toByte, MsgPack.mByte((-32).toByte)),
-        ((-33).toByte, MsgPack.mByte((-33).toByte)),
-        (Byte.MaxValue, MsgPack.mByte(Byte.MaxValue)),
-        (Byte.MinValue, MsgPack.mByte(Byte.MinValue))
+        (0.toByte, MsgPack.fromByte(0.toByte)),
+        ((-32).toByte, MsgPack.fromByte((-32).toByte)),
+        ((-33).toByte, MsgPack.fromByte((-33).toByte)),
+        (Byte.MaxValue, MsgPack.fromByte(Byte.MaxValue)),
+        (Byte.MinValue, MsgPack.fromByte(Byte.MinValue))
       )
     }
   }
@@ -72,14 +72,14 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Short]") {
     check {
       Seq(
-        (Byte.MaxValue.toShort, MsgPack.mByte(Byte.MaxValue)),
-        (Byte.MinValue.toShort, MsgPack.mByte(Byte.MinValue)),
-        ((Byte.MaxValue.toShort + 1.toShort).toShort, MsgPack.mShort((Byte.MaxValue.toShort + 1.toShort).toShort)),
-        ((Byte.MinValue.toShort - 1.toShort).toShort, MsgPack.mShort((Byte.MinValue.toShort - 1.toShort).toShort)),
-        (255.toShort, MsgPack.mShort(255.toShort)),
-        (256.toShort, MsgPack.mShort(256.toShort)),
-        (Short.MaxValue, MsgPack.mShort(Short.MaxValue)),
-        (Short.MinValue, MsgPack.mShort(Short.MinValue))
+        (Byte.MaxValue.toShort, MsgPack.fromByte(Byte.MaxValue)),
+        (Byte.MinValue.toShort, MsgPack.fromByte(Byte.MinValue)),
+        ((Byte.MaxValue.toShort + 1.toShort).toShort, MsgPack.fromShort((Byte.MaxValue.toShort + 1.toShort).toShort)),
+        ((Byte.MinValue.toShort - 1.toShort).toShort, MsgPack.fromShort((Byte.MinValue.toShort - 1.toShort).toShort)),
+        (255.toShort, MsgPack.fromShort(255.toShort)),
+        (256.toShort, MsgPack.fromShort(256.toShort)),
+        (Short.MaxValue, MsgPack.fromShort(Short.MaxValue)),
+        (Short.MinValue, MsgPack.fromShort(Short.MinValue))
       )
     }
   }
@@ -87,14 +87,14 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Int]") {
     check {
       Seq(
-        (Short.MaxValue.toInt, MsgPack.mShort(Short.MaxValue)),
-        (Short.MinValue.toInt, MsgPack.mShort(Short.MinValue)),
-        (Short.MaxValue.toInt + 1, MsgPack.mInt(Short.MaxValue.toInt + 1)),
-        (Short.MinValue.toInt - 1, MsgPack.mInt(Short.MinValue.toInt - 1)),
-        (65535, MsgPack.mInt(65535)),
-        (65536, MsgPack.mInt(65536)),
-        (Int.MaxValue, MsgPack.mInt(Int.MaxValue)),
-        (Int.MinValue, MsgPack.mInt(Int.MinValue))
+        (Short.MaxValue.toInt, MsgPack.fromShort(Short.MaxValue)),
+        (Short.MinValue.toInt, MsgPack.fromShort(Short.MinValue)),
+        (Short.MaxValue.toInt + 1, MsgPack.fromInt(Short.MaxValue.toInt + 1)),
+        (Short.MinValue.toInt - 1, MsgPack.fromInt(Short.MinValue.toInt - 1)),
+        (65535, MsgPack.fromInt(65535)),
+        (65536, MsgPack.fromInt(65536)),
+        (Int.MaxValue, MsgPack.fromInt(Int.MaxValue)),
+        (Int.MinValue, MsgPack.fromInt(Int.MinValue))
       )
     }
   }
@@ -102,12 +102,12 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Long]") {
     check {
       Seq(
-        (Int.MaxValue.toLong, MsgPack.mInt(Int.MaxValue)),
-        (Int.MinValue.toLong, MsgPack.mInt(Int.MinValue)),
-        (Int.MinValue - 1L, MsgPack.mLong(Int.MinValue - 1L)),
-        (Int.MaxValue + 1L, MsgPack.mLong(Int.MaxValue + 1L)),
-        (Long.MaxValue, MsgPack.mLong(Long.MaxValue)),
-        (Long.MinValue, MsgPack.mLong(Long.MinValue))
+        (Int.MaxValue.toLong, MsgPack.fromInt(Int.MaxValue)),
+        (Int.MinValue.toLong, MsgPack.fromInt(Int.MinValue)),
+        (Int.MinValue - 1L, MsgPack.fromLong(Int.MinValue - 1L)),
+        (Int.MaxValue + 1L, MsgPack.fromLong(Int.MaxValue + 1L)),
+        (Long.MaxValue, MsgPack.fromLong(Long.MaxValue)),
+        (Long.MinValue, MsgPack.fromLong(Long.MinValue))
       )
     }
   }
@@ -115,9 +115,9 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[BigInt]") {
     check {
       Seq(
-        (BigInt(Long.MaxValue), MsgPack.mLong(Long.MaxValue)),
-        (BigInt(Long.MinValue), MsgPack.mLong(Long.MinValue)),
-        ((BigInt(1) << 64) - 1, MsgPack.mBigInt((BigInt(1) << 64) - 1))
+        (BigInt(Long.MaxValue), MsgPack.fromLong(Long.MaxValue)),
+        (BigInt(Long.MinValue), MsgPack.fromLong(Long.MinValue)),
+        ((BigInt(1) << 64) - 1, MsgPack.fromBigInt((BigInt(1) << 64) - 1))
       )
     }
   }
@@ -125,9 +125,9 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Double]") {
     check {
       Seq(
-        (0.0, MsgPack.mDouble(0.0)),
-        (Double.MaxValue, MsgPack.mDouble(Double.MaxValue)),
-        (Double.MinValue, MsgPack.mDouble(Double.MinValue))
+        (0.0, MsgPack.fromDouble(0.0)),
+        (Double.MaxValue, MsgPack.fromDouble(Double.MaxValue)),
+        (Double.MinValue, MsgPack.fromDouble(Double.MinValue))
       )
     }
   }
@@ -145,8 +145,8 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Seq[A]]") {
     check {
       Seq(
-        (Seq(0 to 14: _*), MsgPack.mArr((0 to 14).map(a => MsgPack.mByte(a.toByte)): _*)),
-        (Seq.empty[Int], MsgPack.mArr())
+        (Seq(0 to 14: _*), MsgPack.fromValues((0 to 14).map(a => MsgPack.fromByte(a.toByte)): _*)),
+        (Seq.empty[Int], MsgPack.fromValues())
       )
     }
   }
@@ -154,7 +154,7 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[List[A]]") {
     check {
       Seq(
-        ((0 to 14).toList, MsgPack.mArr((0 to 14).map(a => MsgPack.mByte(a.toByte)): _*))
+        ((0 to 14).toList, MsgPack.fromValues((0 to 14).map(a => MsgPack.fromByte(a.toByte)): _*))
       )
     }
   }
@@ -162,7 +162,7 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Vector[A]]") {
     check {
       Seq(
-        ((0 to 14).toVector, MsgPack.mArr((0 to 14).map(a => MsgPack.mByte(a.toByte)): _*))
+        ((0 to 14).toVector, MsgPack.fromValues((0 to 14).map(a => MsgPack.fromByte(a.toByte)): _*))
       )
     }
   }
@@ -170,10 +170,10 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
   test("Encoder[Map[A, B]]") {
     check {
       Seq(
-        (('a' to 'z').zip(0 to 14).toMap, MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
-          case (k, v) => MsgPack.mStr(k.toString) -> MsgPack.mByte(v.toByte)
+        (('a' to 'z').zip(0 to 14).toMap, MsgPack.fromPairSeq(('a' to 'z').zip(0 to 14).map {
+          case (k, v) => MsgPack.fromString(k.toString) -> MsgPack.fromByte(v.toByte)
         })),
-        (Map.empty[Char, Int], MsgPack.mMap())
+        (Map.empty[Char, Int], MsgPack.fromPairs())
       )
     }
   }
@@ -183,9 +183,10 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
     check {
       Seq(
         (('a' to 'z').zip((0 to 14).map(a => Bar(a.toDouble))).toMap,
-         MsgPack.mMapFromSeq(('a' to 'z').zip(0 to 14).map {
+         MsgPack.fromPairSeq(('a' to 'z').zip(0 to 14).map {
            case (k, v) =>
-             MsgPack.mStr(k.toString) -> MsgPack.mMap(MsgPack.mStr("double") -> MsgPack.mDouble(v.toDouble))
+             MsgPack.fromString(k.toString) -> MsgPack.fromPairs(
+               MsgPack.fromString("double") -> MsgPack.fromDouble(v.toDouble))
          }))
       )
     }
@@ -195,8 +196,8 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
     import mess.codec.generic.derived._
     check {
       Seq(
-        (Qux(None), MsgPack.mMap(MsgPack.mStr("byte")    -> MsgPack.mNil)),
-        (Qux(Some(1)), MsgPack.mMap(MsgPack.mStr("byte") -> MsgPack.mByte(1.toByte)))
+        (Qux(None), MsgPack.fromPairs(MsgPack.fromString("byte")    -> MsgPack.nil)),
+        (Qux(Some(1)), MsgPack.fromPairs(MsgPack.fromString("byte") -> MsgPack.fromByte(1.toByte)))
       )
     }
   }
@@ -211,6 +212,7 @@ class EncoderSpec extends FunSuite with MsgpackHelper {
       case MsgPack.MMap(m) => MsgPack.MMap(m.filterNot(_._2 == MsgPack.MNil))
       case _               => fail()
     }
-    assert(encode(Map("a" -> Some(10), "b" -> None)) == MsgPack.mMap(MsgPack.mStr("a") -> MsgPack.mInt(10)))
+    assert(
+      encode(Map("a" -> Some(10), "b" -> None)) == MsgPack.fromPairs(MsgPack.fromString("a") -> MsgPack.fromInt(10)))
   }
 }


### PR DESCRIPTION
After:

```
[info] Benchmark                Mode  Cnt       Score      Error  Units
[info] GenericBench.decodeFoo  thrpt   20  437204.258 ± 6085.413  ops/s
[info] GenericBench.encodeFoo  thrpt   20  523308.859 ± 7335.136  ops/s
```

Before:

```
[info] Benchmark                Mode  Cnt       Score       Error  Units
[info] GenericBench.decodeFoo  thrpt   20  455813.846 ± 16284.921  ops/s
[info] GenericBench.encodeFoo  thrpt   20  523656.150 ± 34122.593  ops/s
```