### PR TITLE
Improve immutablility of MMap

### DIFF
--- a/modules/core/src/main/scala/mess/Encoder.scala
+++ b/modules/core/src/main/scala/mess/Encoder.scala
@@ -94,33 +94,40 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
 
   implicit final def encodeSeq[A: Encoder]: Encoder[Seq[A]] = new Encoder[Seq[A]] {
     def apply(a: Seq[A]): MsgPack = {
-      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
+      val builder = Vector.newBuilder[MsgPack]
+      builder.sizeHint(a)
+      MsgPack.fromVector(iterLoop(a.iterator, builder))
     }
   }
 
   implicit final def encodeSet[A: Encoder]: Encoder[Set[A]] = new Encoder[Set[A]] {
     def apply(a: Set[A]): MsgPack = {
-      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
+      val builder = Vector.newBuilder[MsgPack]
+      builder.sizeHint(a)
+      MsgPack.fromVector(iterLoop(a.iterator, builder))
     }
   }
 
   implicit final def encodeList[A: Encoder]: Encoder[List[A]] = new Encoder[List[A]] {
     def apply(a: List[A]): MsgPack = {
-      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
+      val builder = Vector.newBuilder[MsgPack]
+      builder.sizeHint(a)
+      MsgPack.fromVector(iterLoop(a.iterator, builder))
     }
   }
 
   implicit final def encodeVector[A: Encoder]: Encoder[Vector[A]] = new Encoder[Vector[A]] {
     def apply(a: Vector[A]): MsgPack = {
-      MsgPack.fromVector(iterLoop(a.iterator, Vector.newBuilder))
+      val builder = Vector.newBuilder[MsgPack]
+      MsgPack.fromVector(iterLoop(a.iterator, builder))
     }
   }
 
   @tailrec private[this] def mapLoop[K, V](it: Iterator[(K, V)],
-                                           acc: mutable.Builder[(MsgPack, MsgPack), Seq[(MsgPack, MsgPack)]])(
+                                           acc: mutable.Builder[(MsgPack, MsgPack), Map[MsgPack, MsgPack]])(
       implicit
       encodeK: Encoder[K],
-      encodeV: Encoder[V]): Seq[(MsgPack, MsgPack)] = {
+      encodeV: Encoder[V]): Map[MsgPack, MsgPack] = {
     if (!it.hasNext) acc.result()
     else {
       val (k, v) = it.next()
@@ -130,8 +137,11 @@ object Encoder extends LowPriorityEncoder with TupleEncoder {
 
   implicit final def encodeMap[K: Encoder, V: Encoder]: Encoder[Map[K, V]] =
     new Encoder[Map[K, V]] {
-      def apply(a: Map[K, V]): MsgPack =
-        MsgPack.fromPairSeq(mapLoop(a.iterator, Seq.newBuilder))
+      def apply(a: Map[K, V]): MsgPack = {
+        val builder = Map.newBuilder[MsgPack, MsgPack]
+        builder.sizeHint(a.size)
+        MsgPack.fromMap(mapLoop(a.iterator, builder))
+      }
     }
 }
 

--- a/modules/core/src/main/scala/mess/codec/generic/DerivedDecoder.scala
+++ b/modules/core/src/main/scala/mess/codec/generic/DerivedDecoder.scala
@@ -1,12 +1,22 @@
 package mess.codec.generic
 
 import export._
+import mess.Decoder.Result
 import mess.{Decoder, TypeMismatchError}
 import mess.ast.MsgPack
 import shapeless._
 import shapeless.labelled.{FieldType, field}
 
-trait DerivedDecoder[A] extends Decoder[A]
+trait DerivedDecoder[A] extends Decoder[A] {
+
+  def apply(m: MsgPack): Decoder.Result[A] =
+    m.asMap match {
+      case Some(a) => decodeMap(a)
+      case _       => Left(TypeMismatchError("FieldType[K, H] :: T", m))
+    }
+
+  def decodeMap(m: Map[MsgPack, MsgPack]): Decoder.Result[A]
+}
 
 @exports
 object DerivedDecoder extends LowPriorityDerivedDecoder
@@ -15,7 +25,8 @@ private[mess] trait LowPriorityDerivedDecoder {
 
   implicit final val decodeHNil: DerivedDecoder[HNil] =
     new DerivedDecoder[HNil] {
-      def apply(a: MsgPack): Decoder.Result[HNil] = Right(HNil)
+      override def apply(a: MsgPack): Decoder.Result[HNil]  = Right(HNil)
+      def decodeMap(m: Map[MsgPack, MsgPack]): Result[HNil] = Right(HNil)
     }
 
   implicit final def decodeLabelledHList[K <: Symbol, H, T <: HList](
@@ -24,25 +35,23 @@ private[mess] trait LowPriorityDerivedDecoder {
       decodeH: Decoder[H],
       decodeT: DerivedDecoder[T]): DerivedDecoder[FieldType[K, H] :: T] =
     new DerivedDecoder[FieldType[K, H] :: T] {
-      def apply(m: MsgPack): Decoder.Result[FieldType[K, H] :: T] = m match {
-        case MsgPack.MMap(a) =>
-          decodeT(m) match {
-            case Right(t) =>
-              val v = a.getOrElse(MsgPack.MString(witK.value.name), MsgPack.MNil)
-              decodeH(v) match {
-                case Right(h) => Right(field[K](h) :: t)
-                case Left(e)  => Left(e)
-              }
-            case Left(e) => Left(e)
-          }
-        case _ => Left(TypeMismatchError("FieldType[K, H] :: T", m))
+      def decodeMap(m: Map[MsgPack, MsgPack]): Result[FieldType[K, H] :: T] = {
+        decodeT.decodeMap(m) match {
+          case Right(t) =>
+            val v = m.getOrElse(MsgPack.MString(witK.value.name), MsgPack.MNil)
+            decodeH(v) match {
+              case Right(h) => Right(field[K](h) :: t)
+              case Left(e)  => Left(e)
+            }
+          case Left(e) => Left(e)
+        }
       }
     }
 
   implicit final val decodeCNil: DerivedDecoder[CNil] =
     new DerivedDecoder[CNil] {
-      override def apply(m: MsgPack): Decoder.Result[CNil] =
-        Left(TypeMismatchError("CNil", m))
+      override def apply(m: MsgPack): Result[CNil]          = Left(TypeMismatchError("CNil", m))
+      def decodeMap(m: Map[MsgPack, MsgPack]): Result[CNil] = sys.error("Should be not invoked")
     }
 
   implicit final def decodeLabelledCCons[K <: Symbol, L, R <: Coproduct](
@@ -51,14 +60,17 @@ private[mess] trait LowPriorityDerivedDecoder {
       decodeL: Decoder[L],
       decodeR: DerivedDecoder[R]): DerivedDecoder[FieldType[K, L] :+: R] = {
     new DerivedDecoder[FieldType[K, L] :+: R] {
-      override def apply(m: MsgPack): Decoder.Result[FieldType[K, L] :+: R] = m match {
+      override def apply(m: MsgPack): Result[FieldType[K, L] :+: R] = m match {
         case MsgPack.MMap(a) =>
-          val v = a.getOrElse(MsgPack.fromString(witK.value.name), MsgPack.MNil)
-          decodeL.map(v => Inl(field[K](v))).apply(v) match {
+          decodeMap(a) match {
             case r @ Right(_) => r
-            case Left(_)      => decodeR.map(vv => Inr(vv)).apply(m)
+            case Left(_)      => decodeR.map(Inr.apply).apply(m)
           }
         case _ => Left(TypeMismatchError("FieldType[K, L] :+: R", m))
+      }
+      def decodeMap(m: Map[MsgPack, MsgPack]): Result[FieldType[K, L] :+: R] = {
+        val v = m.getOrElse(MsgPack.fromString(witK.value.name), MsgPack.MNil)
+        decodeL.map(l => Inl(field[K](l))).apply(v)
       }
     }
   }
@@ -67,9 +79,10 @@ private[mess] trait LowPriorityDerivedDecoder {
                                      gen: LabelledGeneric.Aux[A, R],
                                      decodeR: Lazy[DerivedDecoder[R]]): DerivedDecoder[A] =
     new DerivedDecoder[A] {
-      def apply(a: MsgPack): Decoder.Result[A] = decodeR.value(a) match {
-        case Right(v) => Right(gen.from(v))
-        case Left(e)  => Left(e)
-      }
+      def decodeMap(m: Map[MsgPack, MsgPack]): Result[A] =
+        decodeR.value.decodeMap(m) match {
+          case Right(v) => Right(gen.from(v))
+          case Left(e)  => Left(e)
+        }
     }
 }

--- a/modules/core/src/main/scala/mess/codec/generic/DerivedEncoder.scala
+++ b/modules/core/src/main/scala/mess/codec/generic/DerivedEncoder.scala
@@ -8,16 +8,21 @@ import shapeless.labelled.FieldType
 
 import scala.collection.mutable
 
-trait DerivedEncoder[A] extends Encoder[A]
+trait DerivedEncoder[A] extends Encoder[A] {
+  def apply(a: A): MsgPack = MsgPack.fromMap(mapBuilder(a).result())
+  def mapBuilder(a: A): mutable.Builder[(MsgPack, MsgPack), Map[MsgPack, MsgPack]]
+}
 
 @exports
 object DerivedEncoder extends LowPriorityDerivedEncoder
 
 private[mess] trait LowPriorityDerivedEncoder {
 
+  private type Result = mutable.Builder[(MsgPack, MsgPack), Map[MsgPack, MsgPack]]
+
   implicit final val encodeHNil: DerivedEncoder[HNil] =
     new DerivedEncoder[HNil] {
-      def apply(a: HNil): MsgPack = MsgPack.MMap(mutable.HashMap.empty)
+      def mapBuilder(a: HNil): Result = Map.newBuilder
     }
 
   implicit final def encodeLabelledHList[K <: Symbol, H, T <: HList](
@@ -27,16 +32,14 @@ private[mess] trait LowPriorityDerivedEncoder {
       encodeH: Encoder[H],
       encodeT: DerivedEncoder[T]): DerivedEncoder[FieldType[K, H] :: T] =
     new DerivedEncoder[FieldType[K, H] :: T] {
-      def apply(a: FieldType[K, H] :: T): MsgPack =
-        encodeT(a.tail) match {
-          case tt: MsgPack.MMap => tt.add(encodeK(witK.value), encodeH(a.head))
-          case tt               => tt
-        }
+      def mapBuilder(a: FieldType[K, H] :: T): Result =
+        encodeT.mapBuilder(a.tail) += encodeK(witK.value) -> encodeH(a.head)
     }
 
   implicit final val encodeCNil: DerivedEncoder[CNil] =
     new DerivedEncoder[CNil] {
-      def apply(a: CNil): MsgPack = sys.error("Cannot encode CNil")
+      override def apply(a: CNil): MsgPack = sys.error("Cannot encode CNil")
+      def mapBuilder(a: CNil): Result      = sys.error("Should be not invoked")
     }
 
   implicit final def encodeLabelledCCons[K <: Symbol, L, R <: Coproduct](
@@ -45,16 +48,18 @@ private[mess] trait LowPriorityDerivedEncoder {
       encodeL: Encoder[L],
       encodeR: DerivedEncoder[R]): DerivedEncoder[FieldType[K, L] :+: R] =
     new DerivedEncoder[FieldType[K, L] :+: R] {
-      def apply(a: FieldType[K, L] :+: R): MsgPack = a match {
-        case Inl(h) => MsgPack.MMap(mutable.HashMap.empty += MsgPack.fromString(witK.value.name) -> encodeL(h))
+      override def apply(a: FieldType[K, L] :+: R): MsgPack = a match {
+        case Inl(h) => MsgPack.fromPairs(MsgPack.fromString(witK.value.name) -> encodeL(h))
         case Inr(t) => encodeR(t)
       }
+      def mapBuilder(a: FieldType[K, L] :+: R): Result = sys.error("Should be not invoked")
     }
 
   implicit final def encodeGen[A, R](implicit
                                      gen: LabelledGeneric.Aux[A, R],
                                      encodeR: Lazy[DerivedEncoder[R]]): DerivedEncoder[A] =
     new DerivedEncoder[A] {
-      def apply(a: A): MsgPack = encodeR.value(gen.to(a))
+      override def apply(a: A): MsgPack = encodeR.value(gen.to(a))
+      def mapBuilder(a: A): Result      = encodeR.value.mapBuilder(gen.to(a))
     }
 }


### PR DESCRIPTION
After:

```
[info] Benchmark                                             Mode  Cnt       Score      Error   Units
[info] GenericBench.decodeFoo                               thrpt   20  343880.808 ± 4494.298   ops/s
[info] GenericBench.decodeFoo:·gc.alloc.rate                thrpt   20    5596.513 ±   72.122  MB/sec
[info] GenericBench.decodeFoo:·gc.alloc.rate.norm           thrpt   20   18784.001 ±   14.255    B/op
[info] GenericBench.decodeFoo:·gc.churn.G1_Eden_Space       thrpt   20    5674.959 ±   82.305  MB/sec
[info] GenericBench.decodeFoo:·gc.churn.G1_Eden_Space.norm  thrpt   20   19047.610 ±  160.700    B/op
[info] GenericBench.decodeFoo:·gc.churn.G1_Old_Gen          thrpt   20       0.002 ±    0.001  MB/sec
[info] GenericBench.decodeFoo:·gc.churn.G1_Old_Gen.norm     thrpt   20       0.008 ±    0.002    B/op
[info] GenericBench.decodeFoo:·gc.count                     thrpt   20     611.000             counts
[info] GenericBench.decodeFoo:·gc.time                      thrpt   20     793.000                 ms
[info] GenericBench.encodeFoo                               thrpt   20  434349.884 ± 5455.212   ops/s
[info] GenericBench.encodeFoo:·gc.alloc.rate                thrpt   20    3843.980 ±   46.776  MB/sec
[info] GenericBench.encodeFoo:·gc.alloc.rate.norm           thrpt   20   10216.001 ±   14.255    B/op
[info] GenericBench.encodeFoo:·gc.churn.G1_Eden_Space       thrpt   20    3872.510 ±   94.855  MB/sec
[info] GenericBench.encodeFoo:·gc.churn.G1_Eden_Space.norm  thrpt   20   10290.516 ±  163.473    B/op
[info] GenericBench.encodeFoo:·gc.churn.G1_Old_Gen          thrpt   20       0.001 ±    0.001  MB/sec
[info] GenericBench.encodeFoo:·gc.churn.G1_Old_Gen.norm     thrpt   20       0.003 ±    0.001    B/op
[info] GenericBench.encodeFoo:·gc.count                     thrpt   20     417.000             counts
[info] GenericBench.encodeFoo:·gc.time                      thrpt   20     560.000                 ms
```

Before:

```
[info] Benchmark                                             Mode  Cnt       Score       Error   Units
[info] GenericBench.decodeFoo                               thrpt   20  475918.467 ±  9135.225   ops/s
[info] GenericBench.decodeFoo:·gc.alloc.rate                thrpt   20    7556.937 ±   133.773  MB/sec
[info] GenericBench.decodeFoo:·gc.alloc.rate.norm           thrpt   20   18328.001 ±    35.637    B/op
[info] GenericBench.decodeFoo:·gc.churn.G1_Eden_Space       thrpt   20    7661.238 ±   155.571  MB/sec
[info] GenericBench.decodeFoo:·gc.churn.G1_Eden_Space.norm  thrpt   20   18580.429 ±   142.582    B/op
[info] GenericBench.decodeFoo:·gc.churn.G1_Old_Gen          thrpt   20       0.004 ±     0.001  MB/sec
[info] GenericBench.decodeFoo:·gc.churn.G1_Old_Gen.norm     thrpt   20       0.010 ±     0.002    B/op
[info] GenericBench.decodeFoo:·gc.count                     thrpt   20     825.000              counts
[info] GenericBench.decodeFoo:·gc.time                      thrpt   20    1080.000                  ms
[info] GenericBench.encodeFoo                               thrpt   20  612437.225 ± 13027.842   ops/s
[info] GenericBench.encodeFoo:·gc.alloc.rate                thrpt   20    5190.974 ±   113.353  MB/sec
[info] GenericBench.encodeFoo:·gc.alloc.rate.norm           thrpt   20    9784.000 ±     7.127    B/op
[info] GenericBench.encodeFoo:·gc.churn.G1_Eden_Space       thrpt   20    5246.507 ±   137.911  MB/sec
[info] GenericBench.encodeFoo:·gc.churn.G1_Eden_Space.norm  thrpt   20    9888.165 ±   114.119    B/op
[info] GenericBench.encodeFoo:·gc.churn.G1_Old_Gen          thrpt   20       0.002 ±     0.001  MB/sec
[info] GenericBench.encodeFoo:·gc.churn.G1_Old_Gen.norm     thrpt   20       0.005 ±     0.001    B/op
[info] GenericBench.encodeFoo:·gc.count                     thrpt   20     565.000              counts
[info] GenericBench.encodeFoo:·gc.time                      thrpt   20     744.000                  ms
```